### PR TITLE
add metalctl network ip issues command

### DIFF
--- a/cmd/printer.go
+++ b/cmd/printer.go
@@ -924,12 +924,13 @@ func (m MetalIPTablePrinter) Print(data []*models.V1IPResponse) {
 			}
 		}
 		name := truncate(i.Name, "...", 30)
-		row := []string{ipaddress, name, network, project, ipType, strings.Join(shortTags, "\n")}
+		description := truncate(i.Description, "...", 30)
+		row := []string{ipaddress, description, name, network, project, ipType, strings.Join(shortTags, "\n")}
 		wide := []string{ipaddress, i.Description, i.Name, network, project, ipType, strings.Join(i.Tags, "\n")}
 		m.addShortData(row, i)
 		m.addWideData(wide, i)
 	}
-	m.shortHeader = []string{"IP", "Name", "Network", "Project", "Type", "Tags"}
+	m.shortHeader = []string{"IP", "Description", "Name", "Network", "Project", "Type", "Tags"}
 	m.wideHeader = []string{"IP", "Description", "Name", "Network", "Project", "Type", "Tags"}
 	m.render()
 }


### PR DESCRIPTION
Resolves #16 

Sample output:
```
10.65.184.11    hostname mismatch               shoot--pz9cj...5cf6676c5-7m8zx  9f83861b-09b9-4a6c-9a19-adb91fd918b1    2c83b020-aa03-4535-8978-6676b0491584    ephemeral       machine:0930a400-6a63-11e9-8000-ac1f6b7b779e
10.65.184.13    autoassigned, but no tags       shoot--pz9cj...5cf6676c5-6pfpl  9f83861b-09b9-4a6c-9a19-adb91fd918b1    2c83b020-aa03-4535-8978-6676b0491584    ephemeral                                                   
10.65.184.15    bound to unallocated machine    shoot--pz9cj...5cf6676c5-2tgtc  9f83861b-09b9-4a6c-9a19-adb91fd918b1    2c83b020-aa03-4535-8978-6676b0491584    ephemeral       machine:bbbe3200-6a76-11e9-8000-ac1f6b7bece4
185.153.67.35   metallb ip without tags         metallb-52ae1                   internet-fel-wps101                     10241dd7-a8de-4856-8ac0-b55830b22036    ephemeral      
```