### PR TITLE
fix --mac filter for machine ls

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -504,7 +504,7 @@ func machineCreateRequest() (*metalgo.MachineCreateRequest, error) {
 func machineList(driver *metalgo.Driver) error {
 	var resp *metalgo.MachineListResponse
 	var err error
-	if atLeastOneViperStringFlagGiven("id", "partition", "size", "name", "project", "image", "hostname") ||
+	if atLeastOneViperStringFlagGiven("id", "partition", "size", "name", "project", "image", "hostname", "mac") ||
 		atLeastOneViperStringSliceFlagGiven("tags") {
 		mfr := &metalgo.MachineFindRequest{}
 		if filterOpts.ID != "" {


### PR DESCRIPTION
fixes https://github.com/metal-stack/metal-api/issues/61 for `metalctl machine ls`

```
$ metalctl machine ls --mac asdf
ID                      LAST EVENT      WHEN    AGE     HOSTNAME        PROJECT SIZE    IMAGE   PARTITION 

$ metalctl machine ls --mac "00:04:00:11:11:01"
ID                                                      LAST EVENT      WHEN    AGE     HOSTNAME        PROJECT SIZE            IMAGE   PARTITION 
e0ab02d2-27cd-5a5e-8efc-080ba80cf258                    Waiting         49s                                     v1-small-x86            vagrant
```

```
$ metalctl machine ipmi --mac asdf
ID              IP      MAC     BOARD PART NUMBER       BIOS VERSION    BMC VERSION     SIZE    PARTITION 

$metalctl machine ipmi --mac "00:04:00:11:11:01"
ID                                              IP                      MAC                     BOARD PART NUMBER       BIOS VERSION    BMC VERSION     SIZE            PARTITION 
e0ab02d2-27cd-5a5e-8efc-080ba80cf258            192.168.121.1:6231      00:00:00:00:00:00                               0.0.0                           v1-small-x86 
```