### PR TITLE
Add support for ed25519 ssh keys

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -371,7 +371,7 @@ func addMachineCreateFlags(cmd *cobra.Command, name string) {
 	cmd.Flags().StringP("sshpublickey", "p", "",
 		`SSH public key for access via ssh and console. [optional]
 Can be either the public key as string, or pointing to the public key file to use e.g.: "@~/.ssh/id_rsa.pub".
-If ~/.ssh/id_rsa.pub is present it will be picked as default.`)
+If ~/.ssh/[id_ed25519.pub | id_rsa.pub | id_dsa.pub] is present it will be picked as default.`)
 	cmd.Flags().StringSlice("tags", []string{}, "tags to add to the "+name+", use it like: --tags \"tag1,tag2\" or --tags \"tag3\".")
 	cmd.Flags().StringP("userdata", "", "", `cloud-init.io compatible userdata. [optional]
 Can be either the userdata as string, or pointing to the userdata file to use e.g.: "@/tmp/userdata.cfg".`)

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -457,13 +457,12 @@ func machineCreateRequest() (*metalgo.MachineCreateRequest, error) {
 	}
 
 	if len(sshPublicKeyArgument) == 0 {
-		var err error
 		sshKey, err := searchSSHKey()
 		if err != nil {
 			return nil, err
 		}
-		sshKey += ".pub"
-		sshPublicKeyArgument, err = readFromFile(sshKey)
+		sshPublicKey := sshKey + ".pub"
+		sshPublicKeyArgument, err = readFromFile(sshPublicKey)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -457,9 +457,12 @@ func machineCreateRequest() (*metalgo.MachineCreateRequest, error) {
 	}
 
 	if len(sshPublicKeyArgument) == 0 {
-		sshKey, _ := searchSSHKey()
-		sshKey += ".pub"
 		var err error
+		sshKey, err := searchSSHKey()
+		if err != nil {
+			return nil, err
+		}
+		sshKey += ".pub"
 		sshPublicKeyArgument, err = readFromFile(sshKey)
 		if err != nil {
 			return nil, err

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -369,7 +369,7 @@ func addMachineCreateFlags(cmd *cobra.Command, name string) {
 	cmd.Flags().StringP("sshpublickey", "p", "",
 		`SSH public key for access via ssh and console. [optional]
 Can be either the public key as string, or pointing to the public key file to use e.g.: "@~/.ssh/id_rsa.pub".
-If ~/.ssh/[id_ed25519.pub | id_rsa.pub | id_dsa.pub] is present it will be picked as default.`)
+If ~/.ssh/[id_ed25519.pub | id_rsa.pub | id_dsa.pub] is present it will be picked as default, matching the first one in this order.`)
 	cmd.Flags().StringSlice("tags", []string{}, "tags to add to the "+name+", use it like: --tags \"tag1,tag2\" or --tags \"tag3\".")
 	cmd.Flags().StringP("userdata", "", "", `cloud-init.io compatible userdata. [optional]
 Can be either the userdata as string, or pointing to the userdata file to use e.g.: "@/tmp/userdata.cfg".`)

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
 	"strings"
 
 	"fmt"
@@ -457,7 +459,17 @@ func machineCreateRequest() (*metalgo.MachineCreateRequest, error) {
 	}
 
 	if len(sshPublicKeyArgument) == 0 {
-		sshPublicKeyArgument, _ = readFromFile("~/.ssh/id_rsa.pub")
+		currentUser, err := user.Current()
+		homeDir := currentUser.HomeDir
+		defaultDir := filepath.Join(homeDir, "/.ssh/")
+		keys := []string{"id_ed25519.pub", "id_rsa.pub", "id_dsa.pub"}
+		for _, k := range keys {
+			defaultKey := filepath.Join(defaultDir, k)
+			sshPublicKeyArgument, err = readFromFile(defaultKey)
+			if err == nil {
+				break
+			}
+		}
 	}
 
 	var keys []string

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -457,9 +457,10 @@ func machineCreateRequest() (*metalgo.MachineCreateRequest, error) {
 	}
 
 	if len(sshPublicKeyArgument) == 0 {
-		sshPublicKey, _ := searchSSHKey(defaultSSHPublicKeys)
+		sshKey, _ := searchSSHKey()
+		sshKey += ".pub"
 		var err error
-		sshPublicKeyArgument, err = readFromFile(sshPublicKey)
+		sshPublicKeyArgument, err = readFromFile(sshKey)
 		if err != nil {
 			return nil, err
 		}
@@ -790,7 +791,7 @@ func machineConsole(driver *metalgo.Driver, args []string) error {
 
 	key := viper.GetString("sshidentity")
 	if key == "" {
-		key, err = searchSSHKey(defaultSSHPrivateKeys)
+		key, err = searchSSHKey()
 		if err != nil {
 			return fmt.Errorf("machine console error:%v", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,11 +26,13 @@ const (
 )
 
 var (
-	ctx       Context
-	printer   Printer
-	detailer  Detailer
-	driverURL string
-	driver    *metalgo.Driver
+	ctx                   Context
+	printer               Printer
+	detailer              Detailer
+	driverURL             string
+	driver                *metalgo.Driver
+	defaultSSHPublicKeys  = [...]string{"id_ed25519.pub", "id_rsa.pub", "id_dsa.pub"}
+	defaultSSHPrivateKeys = [...]string{"id_ed25519", "id_rsa", "id_dsa"}
 
 	// will bind all viper flags to subcommands and
 	// prevent overwrite of identical flag names from other commands
@@ -214,16 +216,15 @@ func initPrinter() {
 	}
 }
 
-func searchSSHIdentity() (string, error) {
+func searchSSHKey(sshKeys [3]string) (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("unable to determine current user for expanding userdata path:%v", err)
 	}
 	homeDir := currentUser.HomeDir
 	defaultDir := filepath.Join(homeDir, "/.ssh/")
-	keys := []string{"id_ed25519", "id_rsa", "id_dsa"}
 	var key string
-	for _, k := range keys {
+	for _, k := range sshKeys {
 		possibleKey := filepath.Join(defaultDir, k)
 		_, err := ioutil.ReadFile(possibleKey)
 		if err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -221,7 +221,7 @@ func searchSSHIdentity() (string, error) {
 	}
 	homeDir := currentUser.HomeDir
 	defaultDir := filepath.Join(homeDir, "/.ssh/")
-	keys := []string{"id_rsa", "id_dsa"}
+	keys := []string{"id_ed25519", "id_rsa", "id_dsa"}
 	var key string
 	for _, k := range keys {
 		possibleKey := filepath.Join(defaultDir, k)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,13 +26,12 @@ const (
 )
 
 var (
-	ctx                   Context
-	printer               Printer
-	detailer              Detailer
-	driverURL             string
-	driver                *metalgo.Driver
-	defaultSSHPublicKeys  = [...]string{"id_ed25519.pub", "id_rsa.pub", "id_dsa.pub"}
-	defaultSSHPrivateKeys = [...]string{"id_ed25519", "id_rsa", "id_dsa"}
+	ctx            Context
+	printer        Printer
+	detailer       Detailer
+	driverURL      string
+	driver         *metalgo.Driver
+	defaultSSHKeys = [...]string{"id_ed25519", "id_rsa", "id_dsa"}
 
 	// will bind all viper flags to subcommands and
 	// prevent overwrite of identical flag names from other commands
@@ -216,7 +215,7 @@ func initPrinter() {
 	}
 }
 
-func searchSSHKey(sshKeys [3]string) (string, error) {
+func searchSSHKey() (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("unable to determine current user for expanding userdata path:%v", err)
@@ -224,7 +223,7 @@ func searchSSHKey(sshKeys [3]string) (string, error) {
 	homeDir := currentUser.HomeDir
 	defaultDir := filepath.Join(homeDir, "/.ssh/")
 	var key string
-	for _, k := range sshKeys {
+	for _, k := range defaultSSHKeys {
 		possibleKey := filepath.Join(defaultDir, k)
 		_, err := ioutil.ReadFile(possibleKey)
 		if err == nil {


### PR DESCRIPTION
Since there are stronger ssh keys to protect a ssh connection, please add ed25519 as one of the defaults.