### PR TITLE
Fix config file lookup on Windows in home directory.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	metalgo "github.com/metal-stack/metal-go"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 
 	"github.com/metal-stack/v"
@@ -160,7 +161,12 @@ func initConfig() {
 	} else {
 		viper.SetConfigName("config")
 		viper.AddConfigPath(fmt.Sprintf("/etc/%s", programName))
-		viper.AddConfigPath(fmt.Sprintf("$HOME/.%s", programName))
+		h, err := homedir.Dir()
+		if err != nil {
+			log.Printf("unable to figure out user home directory, skipping config lookup path: %v", err)
+		} else {
+			viper.AddConfigPath(fmt.Sprintf(h+"/.%s", programName))
+		}
 		viper.AddConfigPath(".")
 		if err := viper.ReadInConfig(); err != nil {
 			usedCfg := viper.ConfigFileUsed()

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,16 @@ go 1.14
 require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
+	github.com/go-openapi/errors v0.19.6
+	github.com/go-openapi/strfmt v0.19.5
+	github.com/go-openapi/swag v0.19.9
+	github.com/go-openapi/validate v0.19.10
 	github.com/metal-stack/masterdata-api v0.7.3
 	github.com/metal-stack/metal-go v0.8.3
 	github.com/metal-stack/metal-lib v0.5.0
 	github.com/metal-stack/updater v1.1.1
 	github.com/metal-stack/v v1.0.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,7 @@ github.com/metal-stack/v v1.0.2/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLc
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=


### PR DESCRIPTION
Use go-homedir instead of viper's $HOME mechanism. References fi-ts/cloudctl#10.