### PR TITLE
Fixing error handling in apply commands

### DIFF
--- a/cmd/partition.go
+++ b/cmd/partition.go
@@ -222,7 +222,7 @@ func partitionApply(driver *metalgo.Driver) error {
 					return fmt.Errorf("partition get error:%v", e.Error())
 				}
 			default:
-				return fmt.Errorf("partition get error:%v", err)
+				return fmt.Errorf("unexpected error on partition get:%v", err)
 			}
 		}
 		if resp.Partition == nil {

--- a/cmd/printer.go
+++ b/cmd/printer.go
@@ -902,7 +902,7 @@ func (m MetalSwitchTablePrinter) Print(data []*models.V1SwitchResponse) {
 		if s.LastSyncError != nil {
 			errorTime := time.Time(*s.LastSyncError.Time)
 			if errorTime.After(syncTime) {
-				syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), *s.LastSyncError.Error)
+				syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), s.LastSyncError.Error)
 			}
 		}
 

--- a/cmd/printer.go
+++ b/cmd/printer.go
@@ -902,7 +902,7 @@ func (m MetalSwitchTablePrinter) Print(data []*models.V1SwitchResponse) {
 		if s.LastSyncError != nil {
 			errorTime := time.Time(*s.LastSyncError.Time)
 			if errorTime.After(syncTime) {
-				syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), strValue(s.LastSyncError.Error))
+				syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), *s.LastSyncError.Error)
 			}
 		}
 

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -238,28 +238,29 @@ func sizeApply(driver *metalgo.Driver) error {
 	for _, iar := range iars {
 		p, err := driver.SizeGet(iar.ID)
 		if err != nil {
-			if e, ok := err.(*sizemodel.FindSizeDefault); ok {
+			switch e := err.(type) {
+			case *sizemodel.FindSizeDefault:
 				if e.Code() != http.StatusNotFound {
-					return fmt.Errorf("size get error:%v", err)
+					return fmt.Errorf("size get error:%v", e.Error())
 				}
+			default:
+				return fmt.Errorf("unexpected error on size get:%v", err)
 			}
 		}
 		if p.Size == nil {
 			resp, err := driver.SizeCreate(iar)
-			if err != nil {
-				return fmt.Errorf("size update error:%v", err)
-			}
-			response = append(response, resp.Size)
-			continue
-		}
-		if p.Size.ID != nil {
-			resp, err := driver.SizeUpdate(iar)
 			if err != nil {
 				return fmt.Errorf("size create error:%v", err)
 			}
 			response = append(response, resp.Size)
 			continue
 		}
+
+		resp, err := driver.SizeUpdate(iar)
+		if err != nil {
+			return fmt.Errorf("size update error:%v", err)
+		}
+		response = append(response, resp.Size)
 	}
 	return detailer.Detail(response)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,12 @@ go 1.14
 require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
+	github.com/go-openapi/errors v0.19.6
+	github.com/go-openapi/strfmt v0.19.5
+	github.com/go-openapi/swag v0.19.9
+	github.com/go-openapi/validate v0.19.10
 	github.com/metal-stack/masterdata-api v0.8.3
-	github.com/metal-stack/metal-go v0.9.0
+	github.com/metal-stack/metal-go v0.9.4
 	github.com/metal-stack/metal-lib v0.6.1
 	github.com/metal-stack/updater v1.1.1
 	github.com/metal-stack/v v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,8 @@ github.com/metal-stack/masterdata-api v0.8.3 h1:Hb4TDDp1HwJUalG1SKp14lctWyUWi2Xx
 github.com/metal-stack/masterdata-api v0.8.3/go.mod h1:vNzStBft4l8ItkUNu7mrdHbSF6kcPLhulByXBifYLkA=
 github.com/metal-stack/metal-go v0.9.0 h1:pug6JgMz9H/PkQqyjHPtsXh2KeH6vVaoxnhE/0QgYWQ=
 github.com/metal-stack/metal-go v0.9.0/go.mod h1:5emMVOjVD2tj6OxCBUYB8Xo1ruBnoP6idwypVV1pzec=
+github.com/metal-stack/metal-go v0.9.4 h1:WmSF3PdC/J/F9SgCC21X6q2M7EN1i2+rSBclTnsvH+k=
+github.com/metal-stack/metal-go v0.9.4/go.mod h1:5emMVOjVD2tj6OxCBUYB8Xo1ruBnoP6idwypVV1pzec=
 github.com/metal-stack/metal-lib v0.5.0 h1:C3QScS7+wNWMiERB+j0x06WpRuTHW6A3rpuILMOAgss=
 github.com/metal-stack/metal-lib v0.5.0/go.mod h1:Vxr1OwM8fef1gtIv9fUiVU4Gq5mkd4ElHMpTjfuuSFQ=
 github.com/metal-stack/metal-lib v0.6.0 h1:qH1Uh9Vy0AgcE8givRcGvTPCKRh34wyK58PvfTgTLEM=


### PR DESCRIPTION
Currently, we just swallow unexpected errors and continue in the code. This leads to odd error messages in the masterdata creation as described in #49.

Requires https://github.com/metal-stack/metal-api/pull/113 in order to work.