### PR TITLE
We dont need this

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          version: '278.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -36,15 +30,6 @@ jobs:
             --build-only metalctl-master
             -x rule2,rule3
             --summary
-
-      - name: Prepare upload
-        run: |
-          mkdir -p metalctl
-          sudo chown -R $(id -u):$(id -g) result
-          mv result/* metalctl
-
-      - name: Upload image tarballs to GCS
-        run: gsutil -m cp -r -p metalctl gs://$GCS_BUCKET
 
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,12 +19,6 @@ jobs:
         id: fork
         run: '["${{ secrets.DOCKER_REGISTRY_TOKEN }}" == ""] && echo "::set-output name=is_fork_pr::true" || echo "::set-output name=is_fork_pr::false"'
 
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          version: '278.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -54,15 +48,4 @@ jobs:
             --build-only metalctl-slug
             -x rule2,rule3
             --summary
-        if: steps.fork.outputs.is_fork_pr == 'false'
-
-      - name: Prepare upload
-        run: |
-          mkdir -p metalctl/pull-requests/${TAG_NAME}
-          sudo chown -R $(id -u):$(id -g) result
-          mv result/* metalctl/pull-requests/${TAG_NAME}
-        if: steps.fork.outputs.is_fork_pr == 'false'
-
-      - name: Upload image tarballs to GCS
-        run: gsutil -m cp -r -p metalctl gs://$GCS_BUCKET
         if: steps.fork.outputs.is_fork_pr == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          version: '278.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -45,15 +39,6 @@ jobs:
             --build-only metalctl-slug
             -x rule2,rule3
             --summary
-
-      - name: Prepare upload
-        run: |
-          mkdir -p metalctl/${TAG_NAME}
-          sudo chown -R $(id -u):$(id -g) result
-          cp result/* metalctl/${TAG_NAME}
-
-      - name: Upload image tarballs to GCS
-        run: gsutil -m cp -r -p metalctl gs://$GCS_BUCKET
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1.0.1


### PR DESCRIPTION
There is no need to push metalctl to images.metal-stack.io, all downloads are available as:
- github release
- docker image