### PR TITLE
version command prints client and server version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 vendor
 .idea
 coverage.out
+metalctl

--- a/cmd/printer.go
+++ b/cmd/printer.go
@@ -254,7 +254,7 @@ func (j JSONPrinter) Print(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal to json:%w", err)
 	}
-	fmt.Printf("%s\n", string(json))
+	fmt.Printf("%s", string(json))
 	return nil
 }
 
@@ -264,7 +264,7 @@ func (y YAMLPrinter) Print(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal to yaml:%w", err)
 	}
-	fmt.Printf("%s\n", string(yml))
+	fmt.Printf("%s", string(yml))
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 
-	"github.com/metal-stack/v"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
@@ -49,7 +47,6 @@ var (
 		Aliases: []string{"m"},
 		Short:   "a cli to manage metal devices.",
 		Long:    "",
-		Version: v.V.String(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			initPrinter()
 		},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,20 +1,31 @@
 package cmd
 
 import (
+	metalmodels "github.com/metal-stack/metal-go/api/models"
+	"github.com/metal-stack/v"
 	"github.com/spf13/cobra"
 )
 
+type Version struct {
+	Client string                   `json:"client"`
+	Server *metalmodels.RestVersion `json:"server"`
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "shows the version server",
-	Long:  "the --version command returns the client version, but this command reaches out to the server's version endpoint.",
+	Short: "print the client and server version information",
+	Long:  "print the client and server version information",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resp, err := driver.VersionGet()
 		if err != nil {
 			return err
 		}
 
-		return detailer.Detail(resp.Version)
+		v := Version{
+			Client: v.V.String(),
+			Server: resp.Version,
+		}
+		return detailer.Detail(v)
 	},
 	PreRun: bindPFlags,
 }


### PR DESCRIPTION
Solves https://github.com/metal-stack/metalctl/issues/80

`metalctl` behavior is now more similar to `kubectl`. `metalctl version` prints both server and client versions:
```
client: 1.1, go1.16.5
server:
    builddate: "2021-03-29T11:30:07Z"
    gitsha1: e843d254
    name: metal-api
    revision: tags/v0.14.1-0-ge843d25
    version: v0.14.1

```

`--version` flag is removed.

One thing that concerns me is that we detailer always prints new line at the end of output(noticeable in `version` and `health` commands output). Is there a reason for that or we can simply remove it?