### PR TITLE
version: always print client version

### DIFF
--- a/cmd/printer.go
+++ b/cmd/printer.go
@@ -254,7 +254,7 @@ func (j JSONPrinter) Print(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal to json:%w", err)
 	}
-	fmt.Printf("%s", string(json))
+	fmt.Printf("%s\n", string(json))
 	return nil
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,14 +1,16 @@
 package cmd
 
 import (
+	"fmt"
+
 	metalmodels "github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/v"
 	"github.com/spf13/cobra"
 )
 
 type Version struct {
-	Client string                   `json:"client"`
-	Server *metalmodels.RestVersion `json:"server"`
+	Client string                   `yaml:"client"`
+	Server *metalmodels.RestVersion `yaml:"server,omitempty"`
 }
 
 var versionCmd = &cobra.Command{
@@ -16,16 +18,22 @@ var versionCmd = &cobra.Command{
 	Short: "print the client and server version information",
 	Long:  "print the client and server version information",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		resp, err := driver.VersionGet()
-		if err != nil {
-			return err
-		}
-
 		v := Version{
 			Client: v.V.String(),
-			Server: resp.Version,
 		}
-		return detailer.Detail(v)
+
+		resp, err := driver.VersionGet()
+		if err == nil {
+			v.Server = resp.Version
+		}
+
+		if err2 := detailer.Detail(v); err2 != nil {
+			return err2
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get server info: %w", err)
+		}
+		return nil
 	},
 	PreRun: bindPFlags,
 }


### PR DESCRIPTION
While implementing `version` cmd for cloudctl, i realized that server connection error handled badly -- if we fail to connect to server,  only error is printed. Fixed that, now if there's no connection, we get output like that:
```
client: 1.1, go1.16.5
Error: failed to get server info: Get "http://localhost:8080/metal/v1/version": dial tcp 127.0.0.1:8080: connect: connection refused
```

cc @majst01 

P.S. also returned new line for JSON printer, looks like it missing it by default(unlike YAML one).