### PR TITLE
Rename to `--kubeconfig`, better output on context switch.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,7 +28,7 @@ var loginCmd = &cobra.Command{
 				return err
 			}
 			console = os.Stdout
-			handler = auth.NewUpdateKubeConfigHandler(viper.GetString("kubeConfig"), console, auth.WithContextName(formatContextName(cloudContext, cs.CurrentContext)))
+			handler = auth.NewUpdateKubeConfigHandler(viper.GetString("kubeconfig"), console, auth.WithContextName(formatContextName(cloudContext, cs.CurrentContext)))
 		}
 
 		scopes := auth.DexScopes

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -1238,7 +1238,7 @@ func machineConsole(driver *metalgo.Driver, args []string) error {
 	if err != nil {
 		return err
 	}
-	authContext, err := getAuthContext(viper.GetString("kubeConfig"))
+	authContext, err := getAuthContext(viper.GetString("kubeconfig"))
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,7 +187,7 @@ func initConfig() {
 
 	// if there is no api token explicitly specified we try to pull it out of the kubeconfig context
 	if apiToken == "" {
-		authContext, err := getAuthContext(viper.GetString("kubeConfig"))
+		authContext, err := getAuthContext(viper.GetString("kubeconfig"))
 		// if there is an error, no kubeconfig exists for us ... this is not really an error
 		// since metalctl can be used in scripting with an hmac-key
 		if err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ apitoken: "alongtoken"
 `)
 	rootCmd.PersistentFlags().StringP("url", "u", "", "api server address. Can be specified with METALCTL_URL environment variable.")
 	rootCmd.PersistentFlags().String("apitoken", "", "api token to authenticate. Can be specified with METALCTL_APITOKEN environment variable.")
-	rootCmd.PersistentFlags().String("kubeconfig", "", "Path to the kube-config to use for authentication and authorization. Is updated by login.")
+	rootCmd.PersistentFlags().String("kubeconfig", "", "Path to the kube-config to use for authentication and authorization. Is updated by login. Uses default path if not specified.")
 	rootCmd.PersistentFlags().StringP("order", "", "", "order by (comma separated) column(s), possible values: size|id|status|event|when|partition|project")
 	rootCmd.PersistentFlags().StringP("output-format", "o", "table", "output format (table|wide|markdown|json|yaml|template), wide is a table with more columns.")
 	rootCmd.PersistentFlags().StringP("template", "", "", `output template for template output-format, go template format.

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -15,7 +15,7 @@ var whoamiCmd = &cobra.Command{
 	Long:  "shows the current user, that will be used to authenticate commands.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		authContext, err := getAuthContext(viper.GetString("kubeConfig"))
+		authContext, err := getAuthContext(viper.GetString("kubeconfig"))
 		if err != nil {
 			return err
 		}

--- a/crush/main.go
+++ b/crush/main.go
@@ -20,7 +20,7 @@ func getAPIToken() string {
 	// if there is no api token explicitly specified we try to pull it out of
 	// the kubeconfig context
 	if apiToken == "" {
-		kubeconfig := viper.GetString("kubeConfig")
+		kubeconfig := viper.GetString("kubeconfig")
 		authContext, err := auth.CurrentAuthContext(kubeconfig)
 		// if there is an error, no kubeconfig exists for us ... this is not really an error
 		// if metalctl is used in scripting with an hmac-key


### PR DESCRIPTION
References https://github.com/fi-ts/cloudctl/pull/105.

## Breaking Change

```BREAKING_CHANGE
The --kubeConfig parameter was renamed to --kubeconfig in order to align with kubectl.
``` 