### PR TITLE
always show last sync error in metalctl switch ls

### DIFF
--- a/cmd/output/printer.go
+++ b/cmd/output/printer.go
@@ -1016,9 +1016,7 @@ func (m MetalSwitchTablePrinter) Print(data []*models.V1SwitchResponse) {
 
 		if s.LastSyncError != nil {
 			errorTime := time.Time(*s.LastSyncError.Time)
-			if errorTime.After(syncTime) {
-				syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), s.LastSyncError.Error)
-			}
+			syncError = fmt.Sprintf("%s ago: %s", humanizeDuration(time.Since(errorTime)), s.LastSyncError.Error)
 		}
 
 		var mode string


### PR DESCRIPTION
Before:
```
$ metalctl switch ls -o wide
ID                      PARTITION       RACK                    MODE            LAST SYNC       SYNC DURATION   LAST SYNC ERROR 
fel-wps101-leaf01       fel-wps101      fel-wps101-rack01       operational     14s             1.432s                          
```

With PR:
```
$ metalctl switch ls -o wide
ID                      PARTITION       RACK                    MODE            LAST SYNC       SYNC DURATION   LAST SYNC ERROR                                                    
fel-wps101-leaf01       fel-wps101      fel-wps101-rack01       operational     20s             1.432s          2h 23m ago: could not apply                                       
                                                                                                                switch config: reloading                                          
                                                                                                                failed failed                                                     

```