### PR TITLE
Don't error when unhealthy.

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"errors"
+
+	metalgo "github.com/metal-stack/metal-go"
+	"github.com/metal-stack/metal-go/api/client/health"
 	"github.com/metal-stack/metalctl/cmd/output"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +17,14 @@ func newHealthCmd(c *config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := c.driver.HealthGet()
 			if err != nil {
-				return err
+				var r *health.HealthInternalServerError
+				if errors.As(err, &r) {
+					resp = &metalgo.HealthGetResponse{
+						Health: r.Payload,
+					}
+				} else {
+					return err
+				}
 			}
 
 			return output.NewDetailer().Detail(resp.Health)


### PR DESCRIPTION
Health returns an error when the API is unhealthy. metalctl should still show the payload of the result though.