### PR TITLE
New cmd to get VPN auth key

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	metalgo "github.com/metal-stack/metal-go"
-	"github.com/metal-stack/metalctl/cmd/completion"
-	"github.com/metal-stack/metalctl/pkg/api"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/metal-stack/metalctl/cmd/completion"
+	"github.com/metal-stack/metalctl/pkg/api"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -108,6 +109,7 @@ metalctl machine list -o template --template "{{ .id }}:{{ .size.id  }}"
 	rootCmd.AddCommand(newLogoutCmd(c))
 	rootCmd.AddCommand(newWhoamiCmd())
 	rootCmd.AddCommand(newContextCmd(c))
+	rootCmd.AddCommand(newVPNCmd(c))
 
 	rootCmd.AddCommand(newUpdateCmd(c.name))
 

--- a/cmd/vpn.go
+++ b/cmd/vpn.go
@@ -51,5 +51,5 @@ func (c *config) vpnAuthKeyCreate() error {
 		return err
 	}
 
-	return output.New().Print(resp.VPN.AuthKey)
+	return output.New().Print(resp.VPN)
 }

--- a/cmd/vpn.go
+++ b/cmd/vpn.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/metal-stack/metalctl/cmd/output"
+
+	"github.com/spf13/cobra"
+)
+
+type vpnOpts struct {
+	ProjectID string
+}
+
+var vpnOptsInstance = &vpnOpts{}
+
+func newVPNCmd(c *config) *cobra.Command {
+	vpnCmd := &cobra.Command{
+		Use:   "vpn",
+		Short: "access VPN",
+		Long:  "access VPN",
+	}
+	vpnKeyCmd := &cobra.Command{
+		Use:   "key",
+		Short: "create an auth key",
+		Long:  "create an auth key to connect to VPN",
+		Example: `auth key for tailscale can be created by this command:
+metalctl vpn key \
+	-- project cluster01
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.vpnAuthKeyCreate()
+		},
+		PreRun: bindPFlags,
+	}
+
+	vpnKeyCmd.Flags().StringVar(&vpnOptsInstance.ProjectID, "project", "", "project ID for which auth key should be created")
+	must(vpnKeyCmd.RegisterFlagCompletionFunc("project", c.comp.ProjectListCompletion))
+	vpnCmd.AddCommand(vpnKeyCmd)
+
+	return vpnCmd
+}
+
+func (c *config) vpnAuthKeyCreate() error {
+	if vpnOptsInstance.ProjectID == "" {
+		return fmt.Errorf("Project ID should be specified")
+	}
+
+	resp, err := c.driver.GetVPNAuthKey(vpnOptsInstance.ProjectID)
+	if err != nil {
+		return err
+	}
+
+	return output.New().Print(resp.VPN.AuthKey)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.13.0
 	github.com/metal-stack/masterdata-api v0.8.12
-	github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414
+	github.com/metal-stack/metal-go v0.18.6-0.20220811170906-cfaf8ab27337
 	github.com/metal-stack/metal-lib v0.9.2
 	github.com/metal-stack/updater v1.1.3
 	github.com/metal-stack/v v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.13.0
 	github.com/metal-stack/masterdata-api v0.8.12
-	github.com/metal-stack/metal-go v0.18.5
+	github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414
 	github.com/metal-stack/metal-lib v0.9.2
 	github.com/metal-stack/updater v1.1.3
 	github.com/metal-stack/v v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/metal-stack/masterdata-api v0.8.12 h1:hfg+g0W1tzs/5mV9RG4+l6pAtH/SMaeEUQujx+50Z7U=
 github.com/metal-stack/masterdata-api v0.8.12/go.mod h1:le/cvZ9nvw9QQ/eVJSrO7rNdwMMuIrQxFalaIcv/GUg=
-github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414 h1:DOU2luoiKE3Ko2SogcOh2eDhFS43c1LW0YjvFTcft8o=
-github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414/go.mod h1:2JU77TT7PrN9PUwCBYreYEOeziCrYvwfzQ4DLFyKSMM=
+github.com/metal-stack/metal-go v0.18.6-0.20220811170906-cfaf8ab27337 h1:O+RG4397kscw08CqwEv/NCP4ZUb2PgXAN2hqYDiFiAE=
+github.com/metal-stack/metal-go v0.18.6-0.20220811170906-cfaf8ab27337/go.mod h1:2JU77TT7PrN9PUwCBYreYEOeziCrYvwfzQ4DLFyKSMM=
 github.com/metal-stack/metal-lib v0.9.2 h1:wgJuXkOmrHfwV1zfFmz3IzKicCZ6TnarYMfQjf9lDLc=
 github.com/metal-stack/metal-lib v0.9.2/go.mod h1:qViw4NXMx8x3Qn8jSKIBreXL25JUrDSZG2McYlK2V/g=
 github.com/metal-stack/security v0.6.4 h1:nCr1Hf2a4qWRCBsNCifPA4Ic4sHfQlrGjxUvksWcRvM=

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/metal-stack/masterdata-api v0.8.12 h1:hfg+g0W1tzs/5mV9RG4+l6pAtH/SMaeEUQujx+50Z7U=
 github.com/metal-stack/masterdata-api v0.8.12/go.mod h1:le/cvZ9nvw9QQ/eVJSrO7rNdwMMuIrQxFalaIcv/GUg=
-github.com/metal-stack/metal-go v0.18.5 h1:ySdF2S/bb+C1qdc2nmEgpRYJEDBN0OaE8DHrM+nthbs=
-github.com/metal-stack/metal-go v0.18.5/go.mod h1:2JU77TT7PrN9PUwCBYreYEOeziCrYvwfzQ4DLFyKSMM=
+github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414 h1:DOU2luoiKE3Ko2SogcOh2eDhFS43c1LW0YjvFTcft8o=
+github.com/metal-stack/metal-go v0.18.6-0.20220809190954-2f4cae8e2414/go.mod h1:2JU77TT7PrN9PUwCBYreYEOeziCrYvwfzQ4DLFyKSMM=
 github.com/metal-stack/metal-lib v0.9.2 h1:wgJuXkOmrHfwV1zfFmz3IzKicCZ6TnarYMfQjf9lDLc=
 github.com/metal-stack/metal-lib v0.9.2/go.mod h1:qViw4NXMx8x3Qn8jSKIBreXL25JUrDSZG2McYlK2V/g=
 github.com/metal-stack/security v0.6.4 h1:nCr1Hf2a4qWRCBsNCifPA4Ic4sHfQlrGjxUvksWcRvM=


### PR DESCRIPTION
Added new command `metalctl vpn key --project [project]` that returns auth key for VPN associated with given project.