### PR TITLE
At least pass correct ipv6 notation if required

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"golang.org/x/net/proxy"
 	"net"
 	"os"
 	"time"
+
+	"golang.org/x/net/proxy"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"


### PR DESCRIPTION
Without this the following error occurs if target node has a ipv6 address:

```
Error: machine console error:failed to connect to proxy at address :1055: socks connect tcp: address fd7a:115c:a1e0::2:22: too many colons in address
```

But still, connection does not work because the route to the destination is not there:
```
/ # tailscale status                                                                                                                                                                                                                                                             
fd7a:115c:a1e0::3 badile-w2s2wqff      00000000-0000-0000-0000-000000000001 linux   -                                                                                                                                                                                            
fd7a:115c:a1e0::2 48eb9200-be80-11e9-8000-3cecef22fc1a-gprmzmmt 00000000-0000-0000-0000-000000000001 linux   active; relay "fra", tx 1436 rx 780                                                                                                                                 
/ # ssh fd7a:115c:a1e0::2                                                                                                                                                                                                                                                        
ssh: connect to host fd7a:115c:a1e0::2 port 22: Network unreachable                                                                                                                                                                                                              
/ # ip route show                                                                                                                                                                                                                                                                
default via 192.168.0.1 dev wlp0s20f3 proto dhcp metric 600                                                                                                                                                                                                                      
169.254.0.0/16 dev wlp0s20f3 scope link metric 1000                                                                                                                                                                                                                              
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown                                                                                                                                                                                                        
172.19.0.0/16 dev br-7085f5a6d64b proto kernel scope link src 172.19.0.1                                                                                                                                                                                                         
192.168.0.0/22 dev wlp0s20f3 proto kernel scope link src 192.168.1.132 metric 600                                                                                                                                                                                                
/ # ip -6 route show                                                                                                                                                                                                                                                             
::1 dev lo proto kernel metric 256 pref medium                                                                                                                                                                                                                                   
2001:db8:1::/64 dev docker0 proto kernel metric 256 linkdown pref medium                                                                                                                                                                                                         
2001:db8:1::/64 dev docker0 metric 1024 linkdown pref medium                                                                                                                                                                                                                     
fc00:f853:ccd:e793::/64 dev br-7085f5a6d64b proto kernel metric 256 pref medium                                                                                                                                                                                                  
fc00:f853:ccd:e793::/64 dev br-7085f5a6d64b metric 1024 pref medium                                                                                                                                                                                                              
fe80::/64 dev docker0 proto kernel metric 256 linkdown pref medium                                                                                                                                                                                                               
fe80::/64 dev br-7085f5a6d64b proto kernel metric 256 pref medium                                                                                                                                                                                                                
fe80::/64 dev tailscale0 proto kernel metric 256 pref medium                                                                                                                                                                                                                     
fe80::/64 dev vethcd20a9e proto kernel metric 256 pref medium                                                                                                                                                                                                                    
fe80::/64 dev wlp0s20f3 proto kernel metric 1024 pref medium   
/ # ip -6 route show table 52                              
-- is empty
```
Adding this route by hand does not work:
```
/ # ip -6 route add fd7a:115c:a1e0::/48 dev tailscale0 table 52
RTNETLINK answers: Operation not permitted
/
```
