### PR TITLE
Fix image single result test not being able to run individually.

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/metal-stack/metalctl/cmd/completion"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -70,6 +71,8 @@ func (c *test[R]) testCmd(t *testing.T) {
 		format := format
 		t.Run(fmt.Sprintf("%v", format.Args()), func(t *testing.T) {
 			mock, out, config := c.newMockConfig(t)
+
+			viper.Reset()
 
 			cmd := newRootCmd(config)
 			os.Args = append([]string{binaryName}, c.cmd(c.want)...)

--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -62,8 +62,8 @@ func Test_ImageCmd_MultiResult(t *testing.T) {
 				image2,
 			},
 			wantTable: pointer.Pointer(`
-ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY 
-debian   debian-name   debian-description   machine    3d           supported   1        
+ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY
+debian   debian-name   debian-description   machine    3d           supported   1
 ubuntu   ubuntu-name   ubuntu-description   machine    3d           supported   1
 `),
 			wantWideTable: pointer.Pointer(`
@@ -129,12 +129,12 @@ func Test_ImageCmd_SingleResult(t *testing.T) {
 			},
 			want: image1,
 			wantTable: pointer.Pointer(`
-ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY 
-debian   debian-name   debian-description   machine    3d           supported   1
+ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY
+debian   debian-name   debian-description   machine    3d           supported
 		`),
 			wantWideTable: pointer.Pointer(`
-ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY 
-debian   debian-name   debian-description   machine    3d           supported   abc-def
+ID       NAME          DESCRIPTION          FEATURES   EXPIRATION   STATUS      USEDBY
+debian   debian-name   debian-description   machine    3d           supported
 		`),
 			template: pointer.Pointer("{{ .id }} {{ .name }}"),
 			wantTemplate: pointer.Pointer(`
@@ -143,7 +143,7 @@ debian debian-name
 			wantMarkdown: pointer.Pointer(`
 |   ID   |    NAME     |    DESCRIPTION     | FEATURES | EXPIRATION |  STATUS   | USEDBY |
 |--------|-------------|--------------------|----------|------------|-----------|--------|
-| debian | debian-name | debian-description | machine  | 3d         | supported |      1 |
+| debian | debian-name | debian-description | machine  | 3d         | supported |        |
 		`),
 		},
 		{

--- a/cmd/tableprinters/image.go
+++ b/cmd/tableprinters/image.go
@@ -16,6 +16,7 @@ func (t *TablePrinter) ImageTable(data []*models.V1ImageResponse, wide bool) ([]
 	)
 
 	showUsage := viper.GetBool("show-usage")
+	fmt.Println(showUsage)
 
 	header := []string{"ID", "Name", "Description", "Features", "Expiration", "Status", "UsedBy"}
 

--- a/cmd/tableprinters/image.go
+++ b/cmd/tableprinters/image.go
@@ -12,10 +12,10 @@ import (
 
 func (t *TablePrinter) ImageTable(data []*models.V1ImageResponse, wide bool) ([]string, [][]string, error) {
 	var (
-		rows [][]string
+		rows      [][]string
+		header    = []string{"ID", "Name", "Description", "Features", "Expiration", "Status", "UsedBy"}
+		showUsage = viper.GetBool("show-usage")
 	)
-
-	header := []string{"ID", "Name", "Description", "Features", "Expiration", "Status", "UsedBy"}
 
 	for _, image := range data {
 		id := pointer.SafeDeref(image.ID)
@@ -33,7 +33,7 @@ func (t *TablePrinter) ImageTable(data []*models.V1ImageResponse, wide bool) ([]
 		if wide {
 			usedBy = strings.Join(image.Usedby, "\n")
 		}
-		if !viper.GetBool("show-usage") {
+		if !showUsage {
 			usedBy = ""
 		}
 

--- a/cmd/tableprinters/image.go
+++ b/cmd/tableprinters/image.go
@@ -15,9 +15,6 @@ func (t *TablePrinter) ImageTable(data []*models.V1ImageResponse, wide bool) ([]
 		rows [][]string
 	)
 
-	showUsage := viper.GetBool("show-usage")
-	fmt.Println(showUsage)
-
 	header := []string{"ID", "Name", "Description", "Features", "Expiration", "Status", "UsedBy"}
 
 	for _, image := range data {
@@ -36,7 +33,7 @@ func (t *TablePrinter) ImageTable(data []*models.V1ImageResponse, wide bool) ([]
 		if wide {
 			usedBy = strings.Join(image.Usedby, "\n")
 		}
-		if !showUsage {
+		if !viper.GetBool("show-usage") {
 			usedBy = ""
 		}
 


### PR DESCRIPTION
Somehow when using viper in the tableprinters there are side-effects on other tests being run. Resetting viper before every test fixes it.