### PR TITLE
emoji for shutdown state

### DIFF
--- a/cmd/tableprinters/machine.go
+++ b/cmd/tableprinters/machine.go
@@ -114,6 +114,9 @@ func (t *TablePrinter) getMachineStatusEmojis(liveliness *string, events *models
 		case "RESERVED":
 			emojis = append(emojis, api.Bark)
 			wide = append(wide, "Reserved")
+		case "SHUTDOWN":
+			emojis = append(emojis, api.Sleep)
+			wide = append(wide, "Shutdown")
 		}
 	}
 

--- a/pkg/api/emojis.go
+++ b/pkg/api/emojis.go
@@ -9,6 +9,7 @@ const (
 	Question    = "❓"
 	Skull       = "💀"
 	VPN         = "🛡️ "
+	Sleep       = "💤"
 )
 
 func EmojiHelpText() string {
@@ -23,5 +24,6 @@ Meaning of the emojis:
 ⭕ Machine is in a provisioning crash loop. Flag can be reset through an API-triggered reboot or when the machine reaches the phoned home state.
 🚑 Machine reclaim has failed. The machine was deleted but it is not going back into the available machine pool.
 🛡️  Machine is connected to our VPN, ssh access only possible via this VPN.
+💤 Machine is in shutdown state. The machine was powered off by the pool scaler because the partition's maximum pool size was exceeded.
 `
 }


### PR DESCRIPTION
https://github.com/metal-stack/metal-api/pull/356 introduces the new machine state `SHUTDOWN`, which indicates, that the machine was powered off by the pool scaler.