### PR TITLE
Detect FailedMachineReclaim machine issue before new FSM was introduced.

### DIFF
--- a/pkg/api/issues.go
+++ b/pkg/api/issues.go
@@ -392,7 +392,17 @@ func (i *IssueFailedMachineReclaim) Spec() *issueSpec {
 }
 
 func (i *IssueFailedMachineReclaim) Evaluate(m *models.V1MachineIPMIResponse, c *IssueConfig) bool {
-	return pointer.SafeDeref(pointer.SafeDeref(m.Events).FailedMachineReclaim)
+	if pointer.SafeDeref(pointer.SafeDeref(m.Events).FailedMachineReclaim) {
+		return true
+	}
+
+	// compatibility: before the provisioning FSM was renewed, this state could be detected the following way
+	// we should keep this condition
+	if m.Allocation == nil && pointer.SafeDeref(pointer.SafeDeref(pointer.FirstOrZero(pointer.SafeDeref(m.Events).Log)).Event) == "Phoned Home" {
+		return true
+	}
+
+	return false
 }
 
 func (i *IssueFailedMachineReclaim) Details() string {

--- a/pkg/api/issues_test.go
+++ b/pkg/api/issues_test.go
@@ -30,17 +30,18 @@ var (
 	notAvailableMachine1  = &models.V1MachineIPMIResponse{ID: pointer.Pointer("4"), Partition: &models.V1PartitionResponse{ID: pointer.Pointer("a")}}
 	notAvailableMachine2  = &models.V1MachineIPMIResponse{ID: pointer.Pointer("5"), Liveliness: pointer.Pointer(""), Partition: &models.V1PartitionResponse{ID: pointer.Pointer("a")}}
 	failedReclaimMachine  = &models.V1MachineIPMIResponse{ID: pointer.Pointer("6"), Events: &models.V1MachineRecentProvisioningEvents{FailedMachineReclaim: pointer.Pointer(true)}}
-	crashingMachine       = &models.V1MachineIPMIResponse{ID: pointer.Pointer("7"), Events: &models.V1MachineRecentProvisioningEvents{CrashLoop: pointer.Pointer(true)}}
+	failedReclaimMachine2 = &models.V1MachineIPMIResponse{ID: pointer.Pointer("7"), Events: &models.V1MachineRecentProvisioningEvents{Log: []*models.V1MachineProvisioningEvent{{Event: pointer.Pointer("Phoned Home")}}}}
+	crashingMachine       = &models.V1MachineIPMIResponse{ID: pointer.Pointer("8"), Events: &models.V1MachineRecentProvisioningEvents{CrashLoop: pointer.Pointer(true)}}
 	lastEventErrorMachine = &models.V1MachineIPMIResponse{
-		ID: pointer.Pointer("8"),
+		ID: pointer.Pointer("9"),
 		Events: &models.V1MachineRecentProvisioningEvents{
 			LastErrorEvent: &models.V1MachineProvisioningEvent{
 				Time: strfmt.DateTime(testTime.Add(-5 * time.Minute)),
 			},
 		},
 	}
-	bmcWithoutMacMachine = &models.V1MachineIPMIResponse{ID: pointer.Pointer("9"), Ipmi: &models.V1MachineIPMI{}}
-	bmcWithoutIPMachine  = &models.V1MachineIPMIResponse{ID: pointer.Pointer("10"), Ipmi: &models.V1MachineIPMI{}}
+	bmcWithoutMacMachine = &models.V1MachineIPMIResponse{ID: pointer.Pointer("10"), Ipmi: &models.V1MachineIPMI{}}
+	bmcWithoutIPMachine  = &models.V1MachineIPMIResponse{ID: pointer.Pointer("11"), Ipmi: &models.V1MachineIPMI{}}
 	asnSharedMachine1    = &models.V1MachineIPMIResponse{
 		ID: pointer.Pointer("11"),
 		Allocation: &models.V1MachineAllocation{
@@ -174,6 +175,21 @@ func TestFindIssues(t *testing.T) {
 			want: MachineIssues{
 				{
 					Machine: failedReclaimMachine,
+					Issues: Issues{
+						toIssue(&IssueFailedMachineReclaim{}),
+					},
+				},
+			},
+		},
+		{
+			name: "failed machine reclaim 2",
+			c: &IssueConfig{
+				Only:     []IssueType{IssueTypeFailedMachineReclaim},
+				Machines: []*models.V1MachineIPMIResponse{failedReclaimMachine2, goodMachine},
+			},
+			want: MachineIssues{
+				{
+					Machine: failedReclaimMachine2,
 					Issues: Issues{
 						toIssue(&IssueFailedMachineReclaim{}),
 					},


### PR DESCRIPTION
This helps us to detect machines that are in this state before the FSM was introduced.