### PR TITLE
Add `switch connected-machines` command.

### DIFF
--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -105,11 +105,13 @@ r01leaf01,swp2,44e3a522-5f48-4f3c-9188-41025f9e401e,<b-serial>
 	switchMachinesCmd.Flags().String("os-version", "", "OS version of this switch.")
 	switchMachinesCmd.Flags().String("partition", "", "Partition of this switch.")
 	switchMachinesCmd.Flags().String("rack", "", "Rack of this switch.")
+	switchMachinesCmd.Flags().String("size", "", "Size of the connectedmachines.")
 
 	must(switchMachinesCmd.RegisterFlagCompletionFunc("id", c.comp.SwitchListCompletion))
 	must(switchMachinesCmd.RegisterFlagCompletionFunc("name", c.comp.SwitchNameListCompletion))
 	must(switchMachinesCmd.RegisterFlagCompletionFunc("partition", c.comp.PartitionListCompletion))
 	must(switchMachinesCmd.RegisterFlagCompletionFunc("rack", c.comp.SwitchRackListCompletion))
+	must(switchMachinesCmd.RegisterFlagCompletionFunc("size", c.comp.SizeListCompletion))
 
 	switchReplaceCmd := &cobra.Command{
 		Use:   "replace <switchID>",
@@ -258,6 +260,7 @@ func (c *switchCmd) switchMachines() error {
 	resp, err := c.client.Machine().FindIPMIMachines(machine.NewFindIPMIMachinesParams().WithBody(&models.V1MachineFindRequest{
 		PartitionID: viper.GetString("partition"),
 		Rackid:      viper.GetString("rack"),
+		Sizeid:      viper.GetString("size"),
 	}), nil)
 	if err != nil {
 		return err

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/metal-stack/metal-go/api/client/machine"
 	"github.com/metal-stack/metal-go/api/client/switch_operations"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-lib/pkg/genericcli"
@@ -81,6 +82,35 @@ func newSwitchCmd(c *config) *cobra.Command {
 	must(switchDetailCmd.RegisterFlagCompletionFunc("partition", c.comp.PartitionListCompletion))
 	must(switchDetailCmd.RegisterFlagCompletionFunc("rack", c.comp.SwitchRackListCompletion))
 
+	switchMachinesCmd := &cobra.Command{
+		Use:   "connected-machines",
+		Short: "shows switches with their connected machines",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return w.switchMachines()
+		},
+		Example: `The command will show the machines connected to the switch ports.
+
+Can also be used with -o template in order to generate CSV-style output:
+
+$ metalctl switch connected-machines -o template --template '{{ $machines := .machines }}{{ range .switches }}{{ $switch := . }}{{ range .connections }}{{ $switch.id }},{{ $switch.rack_id }},{{ .nic.name }},{{ .machine_id }},{{ (index $machines .machine_id).ipmi.fru.product_serial }}{{ printf "\n" }}{{ end }}{{ end }}'
+r01leaf01,swp1,f78cc340-e5e8-48ed-8fe7-2336c1e2ded2,<a-serial>
+r01leaf01,swp2,44e3a522-5f48-4f3c-9188-41025f9e401e,<b-serial>
+...
+`,
+	}
+
+	switchMachinesCmd.Flags().String("id", "", "ID of the switch.")
+	switchMachinesCmd.Flags().String("name", "", "Name of the switch.")
+	switchMachinesCmd.Flags().String("os-vendor", "", "OS vendor of this switch.")
+	switchMachinesCmd.Flags().String("os-version", "", "OS version of this switch.")
+	switchMachinesCmd.Flags().String("partition", "", "Partition of this switch.")
+	switchMachinesCmd.Flags().String("rack", "", "Rack of this switch.")
+
+	must(switchMachinesCmd.RegisterFlagCompletionFunc("id", c.comp.SwitchListCompletion))
+	must(switchMachinesCmd.RegisterFlagCompletionFunc("name", c.comp.SwitchNameListCompletion))
+	must(switchMachinesCmd.RegisterFlagCompletionFunc("partition", c.comp.PartitionListCompletion))
+	must(switchMachinesCmd.RegisterFlagCompletionFunc("rack", c.comp.SwitchRackListCompletion))
+
 	switchReplaceCmd := &cobra.Command{
 		Use:   "replace <switchID>",
 		Short: "put a leaf switch into replace mode in preparation for physical replacement. For a description of the steps involved see the long help.",
@@ -120,7 +150,7 @@ Operational steps to replace a switch:
 		ValidArgsFunction: c.comp.SwitchListCompletion,
 	}
 
-	return genericcli.NewCmds(cmdsConfig, switchDetailCmd, switchReplaceCmd, switchSSHCmd, switchConsoleCmd)
+	return genericcli.NewCmds(cmdsConfig, switchDetailCmd, switchMachinesCmd, switchReplaceCmd, switchSSHCmd, switchConsoleCmd)
 }
 
 func (c switchCmd) Get(id string) (*models.V1SwitchResponse, error) {
@@ -212,6 +242,42 @@ func (c *switchCmd) switchDetail() error {
 	}
 
 	return c.listPrinter.Print(result)
+}
+
+func (c *switchCmd) switchMachines() error {
+	switches, err := c.List()
+	if err != nil {
+		return err
+	}
+
+	err = sorters.SwitchSorter().SortBy(switches)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Machine().FindIPMIMachines(machine.NewFindIPMIMachinesParams().WithBody(&models.V1MachineFindRequest{
+		PartitionID: viper.GetString("partition"),
+		Rackid:      viper.GetString("rack"),
+	}), nil)
+	if err != nil {
+		return err
+	}
+
+	machines := map[string]*models.V1MachineIPMIResponse{}
+	for _, m := range resp.Payload {
+		m := m
+
+		if m.ID == nil {
+			continue
+		}
+
+		machines[*m.ID] = m
+	}
+
+	return c.listPrinter.Print(&tableprinters.SwitchesWithMachines{
+		SS: switches,
+		MS: machines,
+	})
 }
 
 func (c *switchCmd) switchReplace(args []string) error {

--- a/cmd/tableprinters/printer.go
+++ b/cmd/tableprinters/printer.go
@@ -55,6 +55,8 @@ func (t *TablePrinter) ToHeaderAndRows(data any, wide bool) ([]string, [][]strin
 		return t.SwitchTable(pointer.WrapInSlice(d), wide)
 	case []*SwitchDetail:
 		return t.SwitchDetailTable(d, wide)
+	case *SwitchesWithMachines:
+		return t.SwitchWithConnectedMachinesTable(d, wide)
 	case *models.V1NetworkResponse:
 		return t.NetworkTable(pointer.WrapInSlice(d), wide)
 	case []*models.V1NetworkResponse:

--- a/cmd/tableprinters/switch.go
+++ b/cmd/tableprinters/switch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
+	"github.com/spf13/viper"
 )
 
 func (t *TablePrinter) SwitchTable(data []*models.V1SwitchResponse, wide bool) ([]string, [][]string, error) {
@@ -110,16 +111,36 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 
 		rows = append(rows, []string{id, "", "", partition, rack})
 
-		sort.Slice(s.Connections, switchInterfaceNameLessFunc(s.Connections))
+		conns := s.Connections
+		if viper.IsSet("size") {
+			conns = []*models.V1SwitchConnection{}
+			for _, conn := range s.Connections {
+				conn := conn
 
-		for i, conn := range s.Connections {
-			m := data.MS[conn.MachineID]
+				m, ok := data.MS[conn.MachineID]
+				if !ok {
+					continue
+				}
 
+				if pointer.SafeDeref(m.Size.ID) == viper.GetString("size") {
+					conns = append(conns, conn)
+				}
+			}
+		}
+
+		sort.Slice(conns, switchInterfaceNameLessFunc(conns))
+
+		for i, conn := range conns {
 			prefix := "├"
-			if i == len(s.Connections)-1 {
+			if i == len(conns)-1 {
 				prefix = "└"
 			}
 			prefix += "─╴"
+
+			m, ok := data.MS[conn.MachineID]
+			if !ok {
+				return nil, nil, fmt.Errorf("switch port %s is connected to a machine which does not exist: %q", pointer.SafeDeref(pointer.SafeDeref(conn.Nic).Name), conn.MachineID)
+			}
 
 			identifier := pointer.SafeDeref(conn.Nic.Identifier)
 			if identifier == "" {

--- a/cmd/tableprinters/switch_test.go
+++ b/cmd/tableprinters/switch_test.go
@@ -1,0 +1,92 @@
+package tableprinters
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/metal-stack/metal-go/api/models"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
+	"github.com/metal-stack/metal-lib/pkg/testcommon"
+)
+
+func Test_switchInterfaceNameLessFunc(t *testing.T) {
+	tests := []struct {
+		name  string
+		conns []*models.V1SwitchConnection
+		want  []*models.V1SwitchConnection
+	}{
+		{
+			name: "sorts interface names for cumulus-like interface names",
+			conns: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp10")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s2")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp9")}},
+			},
+			want: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s2")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp9")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp10")}},
+			},
+		},
+		{
+			name: "sorts interface names for sonic-like interface names",
+			conns: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet49")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet10")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet2")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet11")}},
+			},
+			want: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet2")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet10")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet11")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet49")}},
+			},
+		},
+		{
+			name: "sorts interface names edge cases",
+			conns: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("123")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4w5")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("foo")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s3w3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet100")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4w6")}},
+				{Nic: &models.V1SwitchNic{Name: nil}},
+			},
+			want: []*models.V1SwitchConnection{
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s3w3")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4w5")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("swp1s4w6")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet1")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("Ethernet100")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("")}},
+				{Nic: &models.V1SwitchNic{Name: nil}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("123")}},
+				{Nic: &models.V1SwitchNic{Name: pointer.Pointer("foo")}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sort.Slice(tt.conns, switchInterfaceNameLessFunc(tt.conns))
+
+			if diff := cmp.Diff(tt.conns, tt.want, testcommon.StrFmtDateComparer()); diff != "" {
+				t.Errorf("diff (+got -want):\n %s", diff)
+			}
+		})
+	}
+}

--- a/docs/metalctl_switch_connected-machines.md
+++ b/docs/metalctl_switch_connected-machines.md
@@ -30,6 +30,7 @@ r01leaf01,swp2,44e3a522-5f48-4f3c-9188-41025f9e401e,<b-serial>
       --os-version string   OS version of this switch.
       --partition string    Partition of this switch.
       --rack string         Rack of this switch.
+      --size string         Size of the connectedmachines.
 ```
 
 ### Options inherited from parent commands

--- a/docs/metalctl_switch_connected-machines.md
+++ b/docs/metalctl_switch_connected-machines.md
@@ -1,15 +1,35 @@
-## metalctl switch
+## metalctl switch connected-machines
 
-manage switch entities
+shows switches with their connected machines
 
-### Synopsis
+```
+metalctl switch connected-machines [flags]
+```
 
-switch are the leaf switches in the data center that are controlled by metal-stack.
+### Examples
+
+```
+The command will show the machines connected to the switch ports.
+
+Can also be used with -o template in order to generate CSV-style output:
+
+$ metalctl switch connected-machines -o template --template '{{ $machines := .machines }}{{ range .switches }}{{ $switch := . }}{{ range .connections }}{{ $switch.id }},{{ $switch.rack_id }},{{ .nic.name }},{{ .machine_id }},{{ (index $machines .machine_id).ipmi.fru.product_serial }}{{ printf "\n" }}{{ end }}{{ end }}'
+r01leaf01,swp1,f78cc340-e5e8-48ed-8fe7-2336c1e2ded2,<a-serial>
+r01leaf01,swp2,44e3a522-5f48-4f3c-9188-41025f9e401e,<b-serial>
+...
+
+```
 
 ### Options
 
 ```
-  -h, --help   help for switch
+  -h, --help                help for connected-machines
+      --id string           ID of the switch.
+      --name string         Name of the switch.
+      --os-vendor string    OS vendor of this switch.
+      --os-version string   OS version of this switch.
+      --partition string    Partition of this switch.
+      --rack string         Rack of this switch.
 ```
 
 ### Options inherited from parent commands
@@ -42,15 +62,5 @@ switch are the leaf switches in the data center that are controlled by metal-sta
 
 ### SEE ALSO
 
-* [metalctl](metalctl.md)	 - a cli to manage entities in the metal-stack api
-* [metalctl switch connected-machines](metalctl_switch_connected-machines.md)	 - shows switches with their connected machines
-* [metalctl switch console](metalctl_switch_console.md)	 - connect to the switch console
-* [metalctl switch delete](metalctl_switch_delete.md)	 - deletes the switch
-* [metalctl switch describe](metalctl_switch_describe.md)	 - describes the switch
-* [metalctl switch detail](metalctl_switch_detail.md)	 - switch details
-* [metalctl switch edit](metalctl_switch_edit.md)	 - edit the switch through an editor and update
-* [metalctl switch list](metalctl_switch_list.md)	 - list all switches
-* [metalctl switch replace](metalctl_switch_replace.md)	 - put a leaf switch into replace mode in preparation for physical replacement. For a description of the steps involved see the long help.
-* [metalctl switch ssh](metalctl_switch_ssh.md)	 - connect to the switch via ssh
-* [metalctl switch update](metalctl_switch_update.md)	 - updates the switch
+* [metalctl switch](metalctl_switch.md)	 - manage switch entities
 


### PR DESCRIPTION
Since more than a year I need to generate some output that correlates the machine product serials with the switch ports. 

Therefore, I though it might be useful to add this command such that I can throw away my fork which contains a hackier version of this implementation.