### PR TITLE
For build date use Go-compatible RFC3339 date format, fixes `update check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ BINARY := metalctl-$(GOOS)-$(GOARCH)
 
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --all)
-BUILDDATE := $(shell date --rfc-3339=seconds)
+# gnu date format iso-8601 is parsable with Go RFC3339
+BUILDDATE := $(shell date --iso-8601=seconds)
 VERSION := $(or ${VERSION},$(shell git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD))
 
 ifeq ($(CGO_ENABLED),1)


### PR DESCRIPTION
References https://github.com/fi-ts/cloudctl/pull/259.