### PR TITLE
implement get tenant history command

### DIFF
--- a/docs/metalctl_tenant_history.md
+++ b/docs/metalctl_tenant_history.md
@@ -1,15 +1,17 @@
-## metalctl tenant
+## metalctl tenant history
 
-manage tenant entities
+get tenant at given timestamp
 
-### Synopsis
-
-a tenant belongs to a tenant and groups together entities in metal-stack.
+```
+metalctl tenant history [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for tenant
+      --at string   tenant will be returned at it was at this timestamp
+  -h, --help        help for history
+      --id string   ID of tenant
 ```
 
 ### Options inherited from parent commands
@@ -42,13 +44,5 @@ a tenant belongs to a tenant and groups together entities in metal-stack.
 
 ### SEE ALSO
 
-* [metalctl](metalctl.md)	 - a cli to manage entities in the metal-stack api
-* [metalctl tenant apply](metalctl_tenant_apply.md)	 - applies one or more tenants from a given file
-* [metalctl tenant create](metalctl_tenant_create.md)	 - creates the tenant
-* [metalctl tenant delete](metalctl_tenant_delete.md)	 - deletes the tenant
-* [metalctl tenant describe](metalctl_tenant_describe.md)	 - describes the tenant
-* [metalctl tenant edit](metalctl_tenant_edit.md)	 - edit the tenant through an editor and update
-* [metalctl tenant history](metalctl_tenant_history.md)	 - get tenant at given timestamp
-* [metalctl tenant list](metalctl_tenant_list.md)	 - list all tenants
-* [metalctl tenant update](metalctl_tenant_update.md)	 - updates the tenant
+* [metalctl tenant](metalctl_tenant.md)	 - manage tenant entities
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/google/go-cmp v0.5.9
-	github.com/metal-stack/metal-go v0.24.1
+	github.com/metal-stack/metal-go v0.24.2-0.20231006065021-96e01902da6a
 	github.com/metal-stack/metal-lib v0.13.3
 	github.com/metal-stack/updater v1.1.5
 	github.com/metal-stack/v v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
-github.com/metal-stack/metal-go v0.24.1 h1:S4g3LXeWBELCKIyyCsRMa9B1pC5EClqcX35oV/8xv2U=
-github.com/metal-stack/metal-go v0.24.1/go.mod h1:jNJ0dWIBRwKeJoP+RGqTyE5qLsdZFISFrNHU5m3IDwA=
+github.com/metal-stack/metal-go v0.24.2-0.20231006065021-96e01902da6a h1:QNNX5jguRm07QKSJ2CX7C7/82qgTFhMYwsgwUDhbUtc=
+github.com/metal-stack/metal-go v0.24.2-0.20231006065021-96e01902da6a/go.mod h1:jNJ0dWIBRwKeJoP+RGqTyE5qLsdZFISFrNHU5m3IDwA=
 github.com/metal-stack/metal-lib v0.13.3 h1:BOhwcKHILmBZd2pz2YMOhj8QxzDaz3G0F/CGuYhnu8o=
 github.com/metal-stack/metal-lib v0.13.3/go.mod h1:BAR7fjdoV7DDg8i9GpJQBDaNSFirOcBs0vLYTBnhHQU=
 github.com/metal-stack/security v0.6.7 h1:8wstGy0pdUmphVclAlT+9RKQmx9lF+cIGklJZAB5cIc=


### PR DESCRIPTION
https://github.com/metal-stack/metal-api/issues/463

- [ ] depends on https://github.com/metal-stack/metal-go/pull/133

Seems to be working as expected:
```
$ /home/alex/Documents/github.com/metal-stack/metalctl/bin/metalctl-linux-amd64 tenant history --id metal-stack --at 1696580971
ID            NAME          DESCRIPTION                      LABELS   ANNOTATIONS 
metal-stack   metal-stack   metal-stack tenant, which is                            
                            provider             
```