### PR TITLE
feat: add support for printing bgp state of connected machines

### DIFF
--- a/cmd/tableprinters/switch.go
+++ b/cmd/tableprinters/switch.go
@@ -210,8 +210,18 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 			nic := pointer.SafeDeref(conn.Nic)
 			nicname := pointer.SafeDeref(nic.Name)
 			nicstate := pointer.SafeDeref(nic.Actual)
+			bgpstate := pointer.SafeDeref(nic.BgpPortState)
 			if nicstate != "UP" {
 				nicname = fmt.Sprintf("%s (%s)", nicname, color.RedString(nicstate))
+			}
+			if bgpstate.BgpState != nil && wide {
+				switch *bgpstate.BgpState {
+				case "Established":
+					uptime := time.Since(time.Unix(*bgpstate.BgpTimerUpEstablished, 0)).Round(time.Second)
+					nicname = fmt.Sprintf("%s (BGP:%s(%s))", nicname, *bgpstate.BgpState, uptime)
+				default:
+					nicname = fmt.Sprintf("%s (BGP:%s)", nicname, *bgpstate.BgpState)
+				}
 			}
 
 			if wide {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a
+	github.com/metal-stack/metal-go v0.39.5
 	github.com/metal-stack/metal-lib v0.19.0
 	github.com/metal-stack/updater v1.2.2
 	github.com/metal-stack/v v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/metal-stack/metal-go v0.39.2
+	github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a
 	github.com/metal-stack/metal-lib v0.19.0
 	github.com/metal-stack/updater v1.2.2
 	github.com/metal-stack/v v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a h1:BJPawlApxl6jQo/7tkh5VTnq2j+bLoOoZaEocBv9yYk=
-github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a/go.mod h1:ltItf/Md/z588c7Dr3X6iemCeOFh3rJ8nDL5Dpb9zFQ=
+github.com/metal-stack/metal-go v0.39.5 h1:XLw6By7daBzzelyjBFkkFCcWlD+w/8h3PQtfa8QW56A=
+github.com/metal-stack/metal-go v0.39.5/go.mod h1:ltItf/Md/z588c7Dr3X6iemCeOFh3rJ8nDL5Dpb9zFQ=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
 github.com/metal-stack/security v0.9.0 h1:FYBXJfNJwUw2E0HBa+jay37XF7b6EikEuf4Mw8u04EY=

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/metal-stack/metal-go v0.39.2 h1:E2iZ8f7Qo/z2ClbtICYu4iKn91zFv0RonFmuPlbC6tk=
-github.com/metal-stack/metal-go v0.39.2/go.mod h1:ltItf/Md/z588c7Dr3X6iemCeOFh3rJ8nDL5Dpb9zFQ=
+github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a h1:BJPawlApxl6jQo/7tkh5VTnq2j+bLoOoZaEocBv9yYk=
+github.com/metal-stack/metal-go v0.39.3-0.20241115075449-a32f0b74c86a/go.mod h1:ltItf/Md/z588c7Dr3X6iemCeOFh3rJ8nDL5Dpb9zFQ=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
 github.com/metal-stack/security v0.9.0 h1:FYBXJfNJwUw2E0HBa+jay37XF7b6EikEuf4Mw8u04EY=


### PR DESCRIPTION
## Description

support display of the bgp state of connected machines

```
ID                                           NIC NAME                              IDENTIFIER     PARTITION   RACK        SIZE           HOSTNAME   PRODUCT SERIAL
leaf01                                                                                            mini-lab    test-rack
├─╴e0ab02d2-27cd-5a5e-8efc-080ba80cf258      Ethernet0 (BGP:Established(23m48s))   fortyGigE0/0   mini-lab    test-rack   v1-small-x86   test
└─╴2294c949-88f6-5390-8154-fa53d93a3313      Ethernet4 (BGP:Established(23m48s))   fortyGigE0/4   mini-lab    test-rack   v1-small-x86   fw
leaf02                                                                                            mini-lab    test-rack
├─╴e0ab02d2-27cd-5a5e-8efc-080ba80cf258      Ethernet0 (BGP:Established(23m47s))   fortyGigE0/0   mini-lab    test-rack   v1-small-x86   test
└─╴2294c949-88f6-5390-8154-fa53d93a3313      Ethernet4 (BGP:Established(23m47s))   fortyGigE0/4   mini-lab    test-rack   v1-small-x86   fw
```

References:
- https://github.com/metal-stack/metal-api/issues/590

Depends on:
- https://github.com/metal-stack/metal-api/pull/598

