### PR TITLE
feat: add support for non-Admin HMACs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ contexts:
     client_id: metal_client
     client_secret: 456
     hmac: YOUR_HMAC
+    hmacAuthType: THE_AUTH_TYPE_OF_YOUR_HMAC # Metal-Admin, Metal-Edit or Metal-View
 ```
 
 Optional you can specify `issuer_type: generic` if you use other issuers as Dex, e.g. Keycloak (this will request scopes `openid,profile,email`):

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,6 +203,11 @@ func initConfigWithViperCtx(c *config) error {
 	if hmacKey == "" && ctx.HMAC != nil {
 		hmacKey = *ctx.HMAC
 	}
+	hmacAuthType := viper.GetString("hmac-auth-type")
+	if hmacAuthType == "" && ctx.HMACAuthType != "" {
+		hmacAuthType = ctx.HMACAuthType
+	}
+
 	apiToken := viper.GetString("api-token")
 
 	// if there is no api token explicitly specified we try to pull it out of the kubeconfig context
@@ -215,7 +220,7 @@ func initConfigWithViperCtx(c *config) error {
 		}
 	}
 
-	client, err := metalgo.NewDriver(driverURL, apiToken, hmacKey)
+	client, err := metalgo.NewDriver(driverURL, apiToken, hmacKey, metalgo.AuthType(hmacAuthType))
 	if err != nil {
 		return err
 	}

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -25,11 +25,13 @@ type Context struct {
 	ClientID     string  `yaml:"client_id"`
 	ClientSecret string  `yaml:"client_secret"`
 	HMAC         *string `yaml:"hmac"`
+	HMACAuthType string  `yaml:"hmac_auth_type,omitempty"`
 }
 
 var defaultCtx = Context{
-	ApiURL:    "http://localhost:8080/cloud",
-	IssuerURL: "http://localhost:8080/",
+	ApiURL:       "http://localhost:8080/cloud",
+	IssuerURL:    "http://localhost:8080/",
+	HMACAuthType: "Metal-Admin",
 }
 
 func GetContexts() (*Contexts, error) {


### PR DESCRIPTION
## Description

As of now, using the metalctl is only possible for admins, but not for viewers or editors.
This adds an optional setting to the config to fit the auth type of the hmac. Default is admin to keep backwards compatibility

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
