### PR TITLE
fix: bug which required optional hmac type

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -220,7 +220,15 @@ func initConfigWithViperCtx(c *config) error {
 		}
 	}
 
-	client, err := metalgo.NewDriver(driverURL, apiToken, hmacKey, metalgo.AuthType(hmacAuthType))
+	var (
+		client metalgo.Client
+		err    error
+	)
+	if hmacAuthType != "" {
+		client, err = metalgo.NewDriver(driverURL, apiToken, hmacKey, metalgo.AuthType(hmacAuthType))
+	} else {
+		client, err = metalgo.NewDriver(driverURL, apiToken, hmacKey)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

If not given, this will rely on the default server behavior.

**Alternatively:** make this hmac type mandatory in the config and make this a breaking change.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
