### PR TITLE
Small improvements for switch and tenants table.

### DIFF
--- a/cmd/switch_test.go
+++ b/cmd/switch_test.go
@@ -279,7 +279,8 @@ func Test_SwitchCmd_ConnectedMachinesResult(t *testing.T) {
 								},
 								Ipmi: &models.V1MachineIPMI{
 									Fru: &models.V1MachineFru{
-										ProductSerial: "123",
+										ProductSerial:     "123",
+										ChassisPartSerial: "456",
 									},
 								},
 							},
@@ -315,25 +316,26 @@ func Test_SwitchCmd_ConnectedMachinesResult(t *testing.T) {
 						},
 						Ipmi: &models.V1MachineIPMI{
 							Fru: &models.V1MachineFru{
-								ProductSerial: "123",
+								ProductSerial:     "123",
+								ChassisPartSerial: "456",
 							},
 						},
 					},
 				},
 			},
 			wantTable: pointer.Pointer(`
-ID             NIC NAME        IDENTIFIER   PARTITION   RACK     SIZE            PRODUCT SERIAL
+ID             NIC NAME        IDENTIFIER   PARTITION   RACK     SIZE            PRODUCT SERIAL   CHASSIS SERIAL
 1                                           1           rack-1
-└─╴machine-1   a-name          a-mac        1           rack-1   n1-medium-x86   123
+└─╴machine-1   a-name          a-mac        1           rack-1   n1-medium-x86   123              456
 2                                           1           rack-1
-└─╴machine-1   a-name (DOWN)   a-mac        1           rack-1   n1-medium-x86   123
+└─╴machine-1   a-name (DOWN)   a-mac        1           rack-1   n1-medium-x86   123              456
 `),
 			wantWideTable: pointer.Pointer(`
-ID                  NIC NAME        IDENTIFIER   PARTITION   RACK     SIZE            HOSTNAME   PRODUCT SERIAL
+ID                  NIC NAME        IDENTIFIER   PARTITION   RACK     SIZE            HOSTNAME   PRODUCT SERIAL   CHASSIS SERIAL
 1                                                1           rack-1
-└─╴machine-1   ❓   a-name          a-mac        1           rack-1   n1-medium-x86   alloc-1    123
+└─╴machine-1   ❓   a-name          a-mac        1           rack-1   n1-medium-x86   alloc-1    123              456
 2                                                1           rack-1
-└─╴machine-1   ❓   a-name (DOWN)   a-mac        1           rack-1   n1-medium-x86   alloc-1    123
+└─╴machine-1   ❓   a-name (DOWN)   a-mac        1           rack-1   n1-medium-x86   alloc-1    123              456
 `),
 			template: pointer.Pointer(`{{ $machines := .machines }}{{ range .switches }}{{ $switch := . }}{{ range .connections }}{{ $switch.id }},{{ $switch.rack_id }},{{ .nic.name }},{{ .machine_id }},{{ (index $machines .machine_id).ipmi.fru.product_serial }}{{ printf "\n" }}{{ end }}{{ end }}`),
 			wantTemplate: pointer.Pointer(`

--- a/cmd/tableprinters/switch.go
+++ b/cmd/tableprinters/switch.go
@@ -145,9 +145,9 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 		rows [][]string
 	)
 
-	header := []string{"ID", "NIC Name", "Identifier", "Partition", "Rack", "Size", "Product Serial"}
+	header := []string{"ID", "NIC Name", "Identifier", "Partition", "Rack", "Size", "Product Serial", "Chassis Serial"}
 	if wide {
-		header = []string{"ID", "", "NIC Name", "Identifier", "Partition", "Rack", "Size", "Hostname", "Product Serial"}
+		header = []string{"ID", "", "NIC Name", "Identifier", "Partition", "Rack", "Size", "Hostname", "Product Serial", "Chassis Serial"}
 	}
 	t.t.MutateTable(func(table *tablewriter.Table) {
 		table.SetAutoWrapText(false)
@@ -237,6 +237,7 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 					pointer.SafeDeref(pointer.SafeDeref(m.Size).ID),
 					pointer.SafeDeref(pointer.SafeDeref(m.Allocation).Hostname),
 					pointer.SafeDeref(pointer.SafeDeref(m.Ipmi).Fru).ProductSerial,
+					pointer.SafeDeref(pointer.SafeDeref(m.Ipmi).Fru).ChassisPartSerial,
 				})
 			} else {
 				rows = append(rows, []string{
@@ -247,6 +248,7 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 					m.Rackid,
 					pointer.SafeDeref(pointer.SafeDeref(m.Size).ID),
 					pointer.SafeDeref(pointer.SafeDeref(m.Ipmi).Fru).ProductSerial,
+					pointer.SafeDeref(pointer.SafeDeref(m.Ipmi).Fru).ChassisPartSerial,
 				})
 			}
 		}

--- a/cmd/tableprinters/tenant.go
+++ b/cmd/tableprinters/tenant.go
@@ -13,7 +13,7 @@ func (t *TablePrinter) TenantTable(data []*models.V1TenantResponse, wide bool) (
 		rows [][]string
 	)
 
-	header := []string{"ID", "Name", "Description", "Labels", "Annotations"}
+	header := []string{"ID", "Name", "Description"}
 	if wide {
 		header = []string{"ID", "Name", "Description", "Labels", "Annotations", "Quotas"}
 	}
@@ -58,7 +58,7 @@ func (t *TablePrinter) TenantTable(data []*models.V1TenantResponse, wide bool) (
 		if wide {
 			rows = append(rows, []string{pr.Meta.ID, pr.Name, pr.Description, labels, annotations, strings.Join(quotas, "\n")})
 		} else {
-			rows = append(rows, []string{pr.Meta.ID, pr.Name, pr.Description, labels, annotations})
+			rows = append(rows, []string{pr.Meta.ID, pr.Name, pr.Description})
 		}
 	}
 

--- a/cmd/tenant_test.go
+++ b/cmd/tenant_test.go
@@ -89,9 +89,9 @@ func Test_TenantCmd_MultiResult(t *testing.T) {
 				tenant2,
 			},
 			wantTable: pointer.Pointer(`
-ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS
-1    tenant-1   tenant 1      c        a=b
-2    tenant-2   tenant 2      c        a=b
+ID   NAME       DESCRIPTION
+1    tenant-1   tenant 1
+2    tenant-2   tenant 2
 `),
 			wantWideTable: pointer.Pointer(`
 ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
@@ -108,10 +108,10 @@ ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
 2 tenant-2
 `),
 			wantMarkdown: pointer.Pointer(`
-| ID |   NAME   | DESCRIPTION | LABELS | ANNOTATIONS |
-|----|----------|-------------|--------|-------------|
-|  1 | tenant-1 | tenant 1    | c      | a=b         |
-|  2 | tenant-2 | tenant 2    | c      | a=b         |
+| ID |   NAME   | DESCRIPTION |
+|----|----------|-------------|
+|  1 | tenant-1 | tenant 1    |
+|  2 | tenant-2 | tenant 2    |
 `),
 		},
 		{
@@ -140,24 +140,24 @@ ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
 				tenant1,
 			},
 			wantTable: pointer.Pointer(`
-ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS
-1    tenant-1   tenant 1      c        a=b
-		`),
+ID   NAME       DESCRIPTION
+1    tenant-1   tenant 1
+        `),
 			wantWideTable: pointer.Pointer(`
 ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
 1    tenant-1   tenant 1      c        a=b           1 Cluster(s)
                                                      3 Machine(s)
                                                      2 IP(s)
-		`),
+        `),
 			template: pointer.Pointer("{{ .meta.id }} {{ .name }}"),
 			wantTemplate: pointer.Pointer(`
-		1 tenant-1
-		`),
+        1 tenant-1
+        `),
 			wantMarkdown: pointer.Pointer(`
-| ID |   NAME   | DESCRIPTION | LABELS | ANNOTATIONS |
-|----|----------|-------------|--------|-------------|
-|  1 | tenant-1 | tenant 1    | c      | a=b         |
-		`),
+| ID |   NAME   | DESCRIPTION |
+|----|----------|-------------|
+|  1 | tenant-1 | tenant 1    |
+        `),
 		},
 		{
 			name: "apply",
@@ -268,8 +268,8 @@ func Test_TenantCmd_SingleResult(t *testing.T) {
 			},
 			want: tenant1,
 			wantTable: pointer.Pointer(`
-ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS
-1    tenant-1   tenant 1      c        a=b
+ID   NAME       DESCRIPTION
+1    tenant-1   tenant 1
 `),
 			wantWideTable: pointer.Pointer(`
 ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
@@ -282,9 +282,9 @@ ID   NAME       DESCRIPTION   LABELS   ANNOTATIONS   QUOTAS
 1 tenant-1
 `),
 			wantMarkdown: pointer.Pointer(`
-| ID |   NAME   | DESCRIPTION | LABELS | ANNOTATIONS |
-|----|----------|-------------|--------|-------------|
-|  1 | tenant-1 | tenant 1    | c      | a=b         |
+| ID |   NAME   | DESCRIPTION |
+|----|----------|-------------|
+|  1 | tenant-1 | tenant 1    |
 `),
 		},
 		{


### PR DESCRIPTION
## Description

- Puts chassis serial to switch connected machines such that it is possible to see which machines are sitting in the same chassis
- Remove labels and annotations from tenants because these can be pretty big (e.g. for metalstack.cloud)

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
