### PR TITLE
 hide switches without matching machines in connected-machines table output

### DIFF
--- a/cmd/tableprinters/switch.go
+++ b/cmd/tableprinters/switch.go
@@ -154,14 +154,9 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 		partition := pointer.SafeDeref(pointer.SafeDeref(s.Partition).ID)
 		rack := pointer.SafeDeref(s.RackID)
 
-		if wide {
-			rows = append(rows, []string{id, "", "", "", partition, rack})
-		} else {
-			rows = append(rows, []string{id, "", "", partition, rack})
-		}
-
 		conns := s.Connections
-		if viper.IsSet("size") || viper.IsSet("machine-id") {
+		filtered := viper.IsSet("size") || viper.IsSet("machine-id")
+		if filtered {
 			filteredConns := []*models.V1SwitchConnection{}
 
 			for _, conn := range s.Connections {
@@ -180,6 +175,16 @@ func (t *TablePrinter) SwitchWithConnectedMachinesTable(data *SwitchesWithMachin
 			}
 
 			conns = filteredConns
+		}
+
+		if filtered && len(conns) == 0 {
+			continue
+		}
+
+		if wide {
+			rows = append(rows, []string{id, "", "", "", partition, rack})
+		} else {
+			rows = append(rows, []string{id, "", "", partition, rack})
 		}
 
 		sort.Slice(conns, switchInterfaceNameLessFunc(conns))


### PR DESCRIPTION
## Description

Before:

```
$ metalctl switch connected-machines -o table --machine-id bc891a00-87ee-11eb-8000-3cecef78845c
ID                                       NIC NAME    IDENTIFIER         PARTITION    RACK                SIZE          PRODUCT SERIAL    CHASSIS SERIAL
fel-wps1i01-r01leaf01                                                   fel-wps1i01  fel-wps1i01-rack01
fel-wps1i01-r01leaf02                                                   fel-wps1i01  fel-wps1i01-rack01
fel-wps1i01-r02leaf01                                                   fel-wps1i01  fel-wps1i01-rack02
└─╴bc891a00-87ee-11eb-8000-3cecef78845c  swp4s0      14:44:8f:2b:29:90  fel-wps1i01  fel-wps1i01-rack02  m1-large-x86  E262335X2301905A  C217BAK18P80373
fel-wps1i01-r02leaf01-1                                                 fel-wps1i01  fel-wps1i01-rack02
fel-wps1i01-r02leaf02                                                   fel-wps1i01  fel-wps1i01-rack02
fel-wps1i01-r02leaf02-1                                                 fel-wps1i01  fel-wps1i01-rack02
└─╴bc891a00-87ee-11eb-8000-3cecef78845c  Ethernet12  Eth4/1(Port4)      fel-wps1i01  fel-wps1i01-rack02  m1-large-x86  E262335X2301905A  C217BAK18P80373
fel-wps1i01-r03leaf01                                                   fel-wps1i01  fel-wps1i01-rack03
fel-wps1i01-r03leaf02                                                   fel-wps1i01  fel-wps1i01-rack03
```

With this PR:

```
$ metalctl switch connected-machines -o table --machine-id bc891a00-87ee-11eb-8000-3cecef78845c
ID                                       NIC NAME    IDENTIFIER         PARTITION    RACK                SIZE          PRODUCT SERIAL    CHASSIS SERIAL
fel-wps1i01-r02leaf01                                                   fel-wps1i01  fel-wps1i01-rack02
└─╴bc891a00-87ee-11eb-8000-3cecef78845c  swp4s0      14:44:8f:2b:29:90  fel-wps1i01  fel-wps1i01-rack02  m1-large-x86  E262335X2301905A  C217BAK18P80373
fel-wps1i01-r02leaf02-1                                                 fel-wps1i01  fel-wps1i01-rack02
└─╴bc891a00-87ee-11eb-8000-3cecef78845c  Ethernet12  Eth4/1(Port4)      fel-wps1i01  fel-wps1i01-rack02  m1-large-x86  E262335X2301905A  C217BAK18P80373
```

#### Used AI-Tools ✨

GitHub Copilot (GPT-5.3-Codex)

